### PR TITLE
Fixed The Linked List Deconstructor

### DIFF
--- a/LinkedList.cpp
+++ b/LinkedList.cpp
@@ -142,7 +142,7 @@ LinkedList::~LinkedList()
     {
         p = q;
         q = p -> next;
-        if (q) delete p;
+        delete p;
     }
     cout << "Success: list is deleted." << endl;
 }


### PR DESCRIPTION
With the final "if (q)" in the deconstructor statement the final node in the linked list is not deleted and therefore leaks memory.  Removing it fixes the memory leak.
