### PR TITLE
Added Node Initialization to Fix Issue #4

### DIFF
--- a/LinkedList.h
+++ b/LinkedList.h
@@ -19,6 +19,12 @@ using namespace std;
 //***********************************************************************************
 struct node
 {
+    node() : song("")
+            ,artist("")
+            ,next(NULL)
+    {
+    }
+    
     string song;
     string artist;
     node * next;


### PR DESCRIPTION
With node initialize, the next node will be initialize as NULL instead of random address location which will caused crashing when it executed the while(q) condition. As random address location could be some value, so it will still executed the additional iteration where the "next" node is supposed to be NULL and eventually crashing as it is accessing data which is not initialize.